### PR TITLE
Changing PHP memory_limit from 512M to 192M

### DIFF
--- a/packaging/webapp-tiki-httpd.conf
+++ b/packaging/webapp-tiki-httpd.conf
@@ -1,7 +1,7 @@
 # ClearOS tuning
 <Directory /var/clearos/tiki/webroot>
     # PHP scripting language properties
-    php_value memory_limit 512M
+    php_value memory_limit 192M
     php_value session.save_handler files
     php_value zlib.output_compression 1
     php_value register_globals 0


### PR DESCRIPTION
For most sites, the default value of PHP is fine (128M) but it's good to have higher to make sure almost no one has issues for normal use. If more than 192M is required, it's likely an issue in the script which should be fixed.
